### PR TITLE
[WIP] Adding minimal infrastructure for transforming jax function to unit-aware

### DIFF
--- a/src/jpu/annotation.py
+++ b/src/jpu/annotation.py
@@ -1,0 +1,76 @@
+# mypy: ignore-errors
+
+__all__ = ["with_units"]
+
+from functools import wraps
+
+import jax.linear_util as lu
+from jax import core
+from jax.api_util import flatten_fun_nokwargs
+from jax.interpreters import ad, mlir
+from jax.interpreters import partial_eval as pe
+from jax.interpreters import xla
+from jax.tree_util import tree_flatten, tree_unflatten
+
+
+def with_units(func, *, in_units, out_units):
+    @wraps(func)
+    def wrapped(*args, **kwargs):
+        assert not kwargs
+
+        args_flat, in_tree = tree_flatten(args)
+        in_units_flat, _ = tree_flatten(in_units)
+
+        flat_fun, out_tree = flatten_fun_nokwargs(lu.wrap_init(func), in_tree)
+        out_units_flat, _ = tree_flatten(out_units)
+
+        in_avals = [core.raise_to_shaped(core.get_aval(x)) for x in args_flat]
+        debug = pe.debug_info(func, in_tree, False, "with_units")
+        jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(flat_fun, in_avals, debug)
+        assert not len(consts)
+        closed_call = core.ClosedJaxpr(pe.convert_constvars_jaxpr(jaxpr), ())
+        out_flat = with_units_p.bind(
+            *consts,
+            *args_flat,
+            call=closed_call,
+            in_units=in_units_flat,
+            out_units=out_units_flat,
+        )
+        return tree_unflatten(out_tree(), out_flat)
+
+    return wrapped
+
+
+def _with_units_impl(*args, call: core.ClosedJaxpr, in_units, out_units):
+    del in_units, out_units
+    return core.jaxpr_as_fun(call)(*args)
+
+
+def _with_units_abstract_eval(*in_avals, call: core.ClosedJaxpr, **_):
+    return call.out_avals
+
+
+def _with_units_jvp(primals, tangents, *, call, in_units, out_units):
+    tangents = map(ad.instantiate_zeros, tangents)
+    jvp_call, _ = ad.jvp_jaxpr(call, [True] * len(primals), True)
+    outs = with_units_p.bind(
+        *primals,
+        *tangents,
+        call=jvp_call,
+        in_units=tuple(in_units) + tuple(in_units),
+        out_units=tuple(out_units) + tuple(out_units),  # FIXME
+    )
+    assert len(outs) % 2 == 0, len(outs)
+    return outs[: len(outs) // 2], outs[len(outs) // 2 :]
+
+
+with_units_p = core.Primitive("with_units")
+with_units_p.multiple_results = True
+with_units_p.def_impl(_with_units_impl)
+with_units_p.def_abstract_eval(_with_units_abstract_eval)
+ad.primitive_jvps[with_units_p] = _with_units_jvp
+
+xla.register_initial_style_primitive(with_units_p)
+mlir.register_lowering(
+    with_units_p, mlir.lower_fun(_with_units_impl, multiple_results=True)
+)

--- a/src/jpu/tracer.py
+++ b/src/jpu/tracer.py
@@ -1,0 +1,85 @@
+# mypy: ignore-errors
+
+__all__ = ["units"]
+
+from functools import wraps
+from typing import Any, Dict
+import jax
+from jax._src.util import safe_map
+
+from . import numpy as jnu
+from .registry import UnitRegistry
+
+
+unit_transform_registry = {}
+unit_transform_registry[jax.lax.mul_p] = lambda a, b: a * b
+unit_transform_registry[jax.lax.div_p] = lambda a, b: a / b
+unit_transform_registry[jax.lax.add_p] = lambda a, b: a + b
+unit_transform_registry[jax.lax.exp_p] = jnu.exp
+
+
+def units_jaxpr(jaxpr, literals, *args, input_units):
+    unit_registry = None
+    for a in args:
+        unit_registry = getattr(a, "_REGISTRY", None)
+    if unit_registry is None:
+        unit_registry = UnitRegistry()
+
+    env: Dict[Any, Any] = {}
+
+    def read(var: Any) -> Any:
+        if type(var) is jax.core.Literal:
+            return var.val
+        assert unit_registry is not None
+        return unit_registry.Quantity(*env[var])
+
+    def write(var: Any, val: Any, units: Any = None) -> None:
+        if hasattr(val, "magnitude") and hasattr(val, "units"):
+            if units is not None:
+                val = val.to(units)
+            env[var] = (val.magnitude, val.units)
+        else:
+            env[var] = (val, units)
+
+    safe_map(write, jaxpr.invars, args, input_units)
+    safe_map(write, jaxpr.constvars, literals)
+
+    for eqn in jaxpr.eqns:
+        if eqn.primitive not in unit_transform_registry:
+            raise NotImplementedError(
+                f"Primitive '{eqn.primitive}'' does not have registered unit transformation."
+            )
+        invals = safe_map(read, eqn.invars)
+        outvals = unit_transform_registry[eqn.primitive](*invals, **eqn.params)
+        if not eqn.primitive.multiple_results:
+            outvals = [outvals]
+        safe_map(
+            write,
+            eqn.outvars,
+            (v.magnitude for v in outvals),
+            (v.units for v in outvals),
+        )
+    result = safe_map(read, jaxpr.outvars)
+    if not eqn.primitive.multiple_results:
+        return result[0]
+    return result
+
+
+def units(func, *, input_units=None):
+    @wraps(func)
+    def wrapped(*args, **kwargs):
+        if input_units is None:
+            input_units_val = [None] * len(args)
+        else:
+            input_units_val = input_units
+        args_no_units = [getattr(a, "magnitude", a) for a in args]
+        closed_jaxpr = jax.make_jaxpr(func)(*args_no_units, **kwargs)
+        result = units_jaxpr(
+            closed_jaxpr.jaxpr,
+            closed_jaxpr.literals,
+            *args,
+            input_units=input_units_val,
+        )
+        return result
+
+    return wrapped

--- a/src/jpu/tracer.py
+++ b/src/jpu/tracer.py
@@ -4,12 +4,12 @@ __all__ = ["units"]
 
 from functools import wraps
 from typing import Any, Dict
+
 import jax
 from jax._src.util import safe_map
 
 from . import numpy as jnu
 from .registry import UnitRegistry
-
 
 unit_transform_registry = {}
 unit_transform_registry[jax.lax.mul_p] = lambda a, b: a * b
@@ -53,12 +53,7 @@ def units_jaxpr(jaxpr, literals, *args, input_units):
         outvals = unit_transform_registry[eqn.primitive](*invals, **eqn.params)
         if not eqn.primitive.multiple_results:
             outvals = [outvals]
-        safe_map(
-            write,
-            eqn.outvars,
-            (v.magnitude for v in outvals),
-            (v.units for v in outvals),
-        )
+        safe_map(write, eqn.outvars, outvals)
     result = safe_map(read, jaxpr.outvars)
     if not eqn.primitive.multiple_results:
         return result[0]

--- a/tests/test_tracer.py
+++ b/tests/test_tracer.py
@@ -1,0 +1,18 @@
+# mypy: ignore-errors
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from jpu.registry import UnitRegistry
+from jpu.tracer import units
+
+
+def test_decorator():
+    @units
+    def func(x, y):
+        return jnp.exp(x / (0.5 * y) + 2.3)
+
+    u = UnitRegistry()
+    res = func(jnp.ones(3) * u.m, jnp.array([5.6]) * u.km)
+    assert res.units == u.dimensionless


### PR DESCRIPTION
This builds on conversations on Twitter to sketch an interface for transforming a raw JAX function (using the `jax.numpy` interface directly) into one that supports units. For example:

```python
@units
def func(x, y):
    return jnp.exp(x / (0.5 * y) + 2.3)

u = UnitRegistry()
func(jnp.ones(3) * u.m, jnp.array([5.6]) * u.km)
```

or

```python
@partial(units, input_units=["m", "km"])
def func(x, y):
    return jnp.exp(x / (0.5 * y) + 2.3)

func(jnp.ones(3), jnp.array([5.6]))
```

should both work.

This is so far (very!) incomplete. Some things to do / think about:

- [ ] What to do about literals with units? I think the best bet would be to add a `add_units` or `make_quantity` primitive that decorates the literal with units that we can use when transforming the jaxpr. This might also be useful for implementing correct derivative rules without overloading `grad`. Other ideas?
- [ ] Implement some more primitives. What's a good list to start with?
- [ ] etc.

/cc @shoyer @mattjj @sschoenholz @patrick-kidger