### PR TITLE
Making Quantity satisfy JAX duck type array requirements

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
-
 exclude .*
 prune .github
 prune docs

--- a/src/jpu/__init__.py
+++ b/src/jpu/__init__.py
@@ -2,13 +2,12 @@ __all__ = [
     "monkey",
     "numpy",
     "grad",
-    "is_quantity",
     "value_and_grad",
     "__version__",
     "UnitRegistry",
 ]
 
 from jpu import monkey, numpy
-from jpu.core import grad, is_quantity, value_and_grad
+from jpu.core import grad, value_and_grad
 from jpu.jpu_version import __version__
 from jpu.registry import UnitRegistry

--- a/src/jpu/quantity.py
+++ b/src/jpu/quantity.py
@@ -2,6 +2,7 @@ import warnings
 from functools import partial
 from typing import Generic
 
+import jax.numpy as jnp
 from pint.facets.plain import MagnitudeT, PlainQuantity
 
 from jpu import numpy as jpu_numpy
@@ -62,6 +63,18 @@ class JpuQuantity(Generic[MagnitudeT], PlainQuantity[MagnitudeT]):
             stacklevel=2,
         )
         return self._magnitude.__array__(*args, **kwargs)
+
+    @property
+    def dtype(self):
+        return jnp.asarray(self._magnitude).dtype
+
+    @property
+    def ndim(self):
+        return jnp.ndim(self._magnitude)
+
+    @property
+    def shape(self):
+        return jnp.shape(self._magnitude)
 
     def __len__(self):
         return len(self._magnitude)


### PR DESCRIPTION
Previously a Quantity with a Python scalar magnitude would fail for `jnp.ones_like` (etc.) since `shape` and `dtype` weren't exposed. This explicitly implements those properties for all quantities.