### PR TITLE
adding outer function

### DIFF
--- a/src/jpu/jax_numpy_func.py
+++ b/src/jpu/jax_numpy_func.py
@@ -493,7 +493,7 @@ def implement_mul_func(func):
         return a.units._REGISTRY.Quantity(mag, units)
 
 
-for func_str in ("cross", "dot"):
+for func_str in ("cross", "dot", "outer"):
     implement_mul_func(func_str)
 
 


### PR DESCRIPTION
Adds outer function by adding `outer` to
```
for func_str in ("cross", "dot", "outer"):
    implement_mul_func(func_str)
```
